### PR TITLE
pin a specific airflow version, and adjust permissions so that live update works

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,2 +1,3 @@
-FROM astronomerinc/ap-airflow
+FROM astronomerinc/ap-airflow:1.10.10-4-alpine3.10
 ADD . .
+RUN chmod a+w -R ./dags

--- a/airflow/Tiltfile
+++ b/airflow/Tiltfile
@@ -8,6 +8,7 @@ helm_remote('airflow',
               # Inject the Docker Image containing the Airflow DAG
               'images.airflow.repository=example-dags',
               'images.airflow.tag=dev',
+              'defaultAirflowTag=1.10.10-4-alpine3.10',
 
               'webserver.livenessProbe.timeoutSeconds=300',
               'webserver.livenessProbe.failureThreshold=60',


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/airflow:

018f48e162060a39cf63cff76c93649a516935b3 (2020-08-12 17:00:13 -0400)
pin a specific airflow version, and adjust permissions so that live update works

ac948cb557913eb5a56729304e90e02b12ab0f05 (2020-07-31 12:42:05 -0400)
minor framework improvements - improved timeouts on airflow - tweak the postgres example to also show a custom postgres image

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics