### PR TITLE
fix the airflow tiltfile to create the namespace

### DIFF
--- a/airflow/Tiltfile
+++ b/airflow/Tiltfile
@@ -1,4 +1,7 @@
 load('ext://helm_remote', 'helm_remote')
+load('ext://namespace', 'namespace_create')
+
+namespace_create('airflow')
 
 helm_remote('airflow',
             repo_url='https://helm.astronomer.io',


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/airflow2:

799d40246c8468ab4c080ad584a48a154ccc944c (2020-09-15 10:34:05 -0400)
fix the airflow tiltfile to create the namespace

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics